### PR TITLE
[IT-1801] Fix failures related to python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
     -   id: check-ast
 -   repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.27.1
     hooks:
     -   id: yamllint
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.55.0
+    rev: v0.61.3
     hooks:
     -   id: cfn-python-lint
         files: template\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.10
+    rev: v1.3.0
     hooks:
     -   id: remove-tabs

--- a/s3objects/macro.py
+++ b/s3objects/macro.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -18,6 +18,7 @@ LAMBDA_ARN = os.environ["LAMBDA_ARN"]
 
 s3_client = boto3.client("s3")
 
+
 def handle_template(request_id, template):
     new_resources = {}
 
@@ -25,8 +26,19 @@ def handle_template(request_id, template):
         if resource["Type"] == "AWS::S3::Object":
             props = resource["Properties"]
 
-            if len([prop for prop in resource["Properties"] if prop in ["Body", "Base64Body", "Source"]]) != 1:
-                raise Exception("You must specify exactly one of: Body, Base64Body, Source")
+            if (
+                len(
+                    [
+                        prop
+                        for prop in resource["Properties"]
+                        if prop in ["Body", "Base64Body", "Source"]
+                    ]
+                )
+                != 1
+            ):
+                raise Exception(
+                    "You must specify exactly one of: Body, Base64Body, Source"
+                )
 
             target = props["Target"]
 
@@ -57,6 +69,7 @@ def handle_template(request_id, template):
         template["Resources"][name] = resource
 
     return template
+
 
 def handler(event, context):
     try:

--- a/s3objects/resource.py
+++ b/s3objects/resource.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -19,47 +19,55 @@ import json
 
 s3_client = boto3.client("s3")
 
+
 def sendResponse(event, context, status, message):
     bucket = event["ResourceProperties"].get("Target", {}).get("Bucket")
     key = event["ResourceProperties"].get("Target", {}).get("Key")
 
-    body = json.dumps({
-        "Status": status,
-        "Reason": message,
-        "StackId": event['StackId'],
-        "RequestId": event['RequestId'],
-        "LogicalResourceId": event['LogicalResourceId'],
-        "PhysicalResourceId": "s3://{}/{}".format(bucket, key),
-        "Data": {
-            "Bucket": bucket,
-            "Key": key,
-        },
-    }).encode('utf-8')
+    body = json.dumps(
+        {
+            "Status": status,
+            "Reason": message,
+            "StackId": event["StackId"],
+            "RequestId": event["RequestId"],
+            "LogicalResourceId": event["LogicalResourceId"],
+            "PhysicalResourceId": f"s3://{bucket}/{key}",
+            "Data": {
+                "Bucket": bucket,
+                "Key": key,
+            },
+        }
+    )
 
-    request = Request(event['ResponseURL'], data=body)
-    request.add_header('Content-Type', '')
-    request.add_header('Content-Length', len(body))
-    request.get_method = lambda: 'PUT'
+    request = Request(event["ResponseURL"], data=body.encode("utf-8"))
+    request.add_header("Content-Type", "")
+    request.add_header("Content-Length", len(body))
+    request.get_method = lambda: "PUT"
 
     opener = build_opener(HTTPHandler)
     response = opener.open(request)
 
+
 def handler(event, context):
-    print(("Received request:", json.dumps(event, indent=4)))
+    print("Received request:", json.dumps(event, indent=4))
 
     request = event["RequestType"]
     properties = event["ResourceProperties"]
 
-    if "Target" not in properties or all(prop not in properties for prop in ["Body", "Base64Body", "Source"]):
+    if "Target" not in properties or all(
+        prop not in properties for prop in ["Body", "Base64Body", "Source"]
+    ):
         return sendResponse(event, context, "FAILED", "Missing required parameters")
 
     target = properties["Target"]
 
     if request in ("Create", "Update"):
         if "Body" in properties:
-            target.update({
-                "Body": properties["Body"],
-            })
+            target.update(
+                {
+                    "Body": properties["Body"],
+                }
+            )
 
             s3_client.put_object(**target)
 
@@ -69,9 +77,7 @@ def handler(event, context):
             except:
                 return sendResponse(event, context, "FAILED", "Malformed Base64Body")
 
-            target.update({
-                "Body": body
-            })
+            target.update({"Body": body})
 
             s3_client.put_object(**target)
 
@@ -100,4 +106,4 @@ def handler(event, context):
 
         return sendResponse(event, context, "SUCCESS", "Deleted")
 
-    return sendResponse(event, context, "FAILED", "Unexpected: {}".format(request))
+    return sendResponse(event, context, "FAILED", f"Unexpected: {request}")

--- a/template.yaml
+++ b/template.yaml
@@ -1,4 +1,4 @@
-# From https://github.com/awslabs/aws-cloudformation-templates/tree/master/aws/services/CloudFormation/MacrosExamples/S3Objects
+# From https://github.com/aws-cloudformation/aws-cloudformation-macros/tree/master/S3Objects
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: A Cloudformation macro to deploy objects to S3 buckets


### PR DESCRIPTION
This lambda is failing, probably from PR #6 to update the
python version on it.

Update the lambda to the latest version at from the official
repo[1] which is updated to support python 3.8

* Update code to work with python 3.8
* Update pre-commit linters
* Fix the following error:
```
[ERROR] TypeError: expected string or bytes-like object
Traceback (most recent call last):
  File "/var/task/resource.py", line 64, in handler
    s3_client.put_object(**target)
  File "/var/runtime/botocore/client.py", line 391, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/var/runtime/botocore/client.py", line 691, in _make_api_call
    request_dict = self._convert_to_request_dict(
  File "/var/runtime/botocore/client.py", line 737, in _convert_to_request_dict
    api_params = self._emit_api_params(
  File "/var/runtime/botocore/client.py", line 766, in _emit_api_params
    self.meta.events.emit(
  File "/var/runtime/botocore/hooks.py", line 357, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/var/runtime/botocore/hooks.py", line 228, in emit
    return self._emit(event_name, kwargs)
  File "/var/runtime/botocore/hooks.py", line 211, in _emit
    response = handler(**kwargs)
  File "/var/runtime/botocore/handlers.py", line 238, in validate_bucket_name
    if not VALID_BUCKET.search(bucket) and not VALID_S3_ARN.search(bucket):
```

[1] https://github.com/aws-cloudformation/aws-cloudformation-macros/tree/master/S3Objects

